### PR TITLE
fix: prevent crash when opening video detail via URL

### DIFF
--- a/medialake_user_interface/src/pages/VideoDetailPage.tsx
+++ b/medialake_user_interface/src/pages/VideoDetailPage.tsx
@@ -914,7 +914,7 @@ interface VideoDetailContentProps {
 
 const VideoDetailPage: React.FC = () => {
   const location = useLocation();
-  const { assetType, searchTerm, asset } = location.state;
+  const { assetType, searchTerm, asset } = location.state || {};
   return (
     <RecentlyViewedProvider>
       <RightSidebarProvider>


### PR DESCRIPTION
*Issue #, if available:*
Navigate to video detail page via direct URL causes the page to crash because location.state is `null` initially.

<img width="1512" height="790" alt="Screenshot 2026-02-06 at 10 56 21" src="https://github.com/user-attachments/assets/324fe105-39a6-4c20-b0a8-c39213987eca" />

*Description of changes:*
Add `|| {}` to safely destructure `location.state`, similar to how `AudioDetailPage` and `ImageDetailPage` work.