### PR TITLE
Support use_cli_credentials deployment options in CFN template

### DIFF
--- a/.cicd/config.json-template
+++ b/.cicd/config.json-template
@@ -4,6 +4,9 @@
     "account_id": "<aws_account_id>",
     "resource_prefix": "medialake",
     "resource_application_tag": "medialake",
+    "deployment_options": {
+        "use_cli_credentials": false
+    },
     "api_path": "v1",
     "primary_region": "<aws_region>",
     "initial_user": {

--- a/medialake-with-vpc.template
+++ b/medialake-with-vpc.template
@@ -24,6 +24,11 @@ Parameters:
     Type: String
     Default: 'https://github.com/aws-solutions-library-samples/guidance-for-medialake'
 
+  GitBranch:
+    Description: Git branch to clone from the repository
+    Type: String
+    Default: main
+
   S3PresignedURL:
     Description: Presigned URL for downloading the CDK code ZIP (if S3PresignedURL source type is selected)
     Type: String
@@ -140,6 +145,7 @@ Metadata:
         Parameters:
           - SourceType
           - GitRepositoryUrl
+          - GitBranch
           - S3PresignedURL
     ParameterLabels:
       DeploymentName:
@@ -170,6 +176,8 @@ Metadata:
         default: Source Type
       GitRepositoryUrl:
         default: Git Repository URL
+      GitBranch:
+        default: Git Branch
       S3PresignedURL:
         default: S3 Presigned URL
 
@@ -538,7 +546,7 @@ Resources:
           - Name: GIT_REPOSITORY_URL
             Value: !Ref GitRepositoryUrl
           - Name: GIT_BRANCH
-            Value: main
+            Value: !Ref GitBranch
       Source:
         Type: CODEPIPELINE
         BuildSpec: !Sub |

--- a/medialake-with-vpc.template
+++ b/medialake-with-vpc.template
@@ -71,6 +71,14 @@ Parameters:
     Default: ''
     MaxLength: 63
 
+  UseCliCredentials:
+    Description: Use CDK CliCredentialsStackSynthesizer instead of default bootstrap role synthesizer.
+    Type: String
+    Default: 'false'
+    AllowedValues:
+      - 'true'
+      - 'false'
+
   ExistingVPCId:
     Description: ID of the existing VPC (e.g., vpc-0123456789abcdef0)
     Type: String
@@ -115,6 +123,11 @@ Metadata:
           - ExternalS3Bucket
       -
         Label:
+          default: Deployment Options
+        Parameters:
+          - UseCliCredentials
+      -
+        Label:
           default: VPC Configuration
         Parameters:
           - ExistingVPCId
@@ -143,6 +156,8 @@ Metadata:
         default: OpenSearch Deployment Size
       ExternalS3Bucket:
         default: External S3 Bucket (Optional)
+      UseCliCredentials:
+        default: Use CLI Credentials Synthesizer
       ExistingVPCId:
         default: VPC ID
       ExistingVPCCIDR:
@@ -593,6 +608,8 @@ Resources:
             Value: !Ref DeploymentName
           - Name: IS_DEFAULT_DEPLOYMENT
             Value: !If [IsDefaultDeployment, 'true', 'false']
+          - Name: USE_CLI_CREDENTIALS
+            Value: !Ref UseCliCredentials
       Source:
         Type: CODEPIPELINE
         BuildSpec: !Sub |
@@ -677,6 +694,14 @@ Resources:
                   else
                     echo "Additional deployment '$DEPLOYMENT_NAME' - using prefixed naming"
                     echo "$( jq '.use_prefixed_names = true' config.json )" > config.json
+                  fi
+                - |
+                  if [ "$USE_CLI_CREDENTIALS" = "true" ]; then
+                    echo "Using CLI credentials synthesizer"
+                    echo "$( jq '.deployment_options.use_cli_credentials = true' config.json )" > config.json
+                  else
+                    echo "Using default bootstrap role synthesizer"
+                    echo "$( jq '.deployment_options.use_cli_credentials = false' config.json )" > config.json
                   fi
                 - echo "Final config.json:"
                 - cat config.json

--- a/medialake.template
+++ b/medialake.template
@@ -24,6 +24,11 @@ Parameters:
     Type: String
     Default: 'https://github.com/aws-solutions-library-samples/guidance-for-medialake'
 
+  GitBranch:
+    Description: Git branch to clone from the repository
+    Type: String
+    Default: main
+
   S3PresignedURL:
     Description: Presigned URL for downloading the CDK code ZIP (if S3PresignedURL source type is selected)
     Type: String
@@ -112,6 +117,7 @@ Metadata:
         Parameters:
           - SourceType
           - GitRepositoryUrl
+          - GitBranch
           - S3PresignedURL
     ParameterLabels:
       DeploymentName:
@@ -134,6 +140,8 @@ Metadata:
         default: Source Type
       GitRepositoryUrl:
         default: Git Repository URL
+      GitBranch:
+        default: Git Branch
       S3PresignedURL:
         default: S3 Presigned URL
 
@@ -598,7 +606,7 @@ Resources:
           - Name: GIT_REPOSITORY_URL
             Value: !Ref GitRepositoryUrl
           - Name: GIT_BRANCH
-            Value: main
+            Value: !Ref GitBranch
       Source:
         Type: CODEPIPELINE
         BuildSpec: !Sub |

--- a/medialake.template
+++ b/medialake.template
@@ -71,6 +71,14 @@ Parameters:
     Default: ''
     MaxLength: 63
 
+  UseCliCredentials:
+    Description: Use CDK CliCredentialsStackSynthesizer instead of default bootstrap role synthesizer.
+    Type: String
+    Default: 'false'
+    AllowedValues:
+      - 'true'
+      - 'false'
+
 Metadata:
   AWS::CloudFormation::Interface:
     ParameterGroups:
@@ -95,6 +103,11 @@ Metadata:
           - ExternalS3Bucket
       -
         Label:
+          default: Deployment Options
+        Parameters:
+          - UseCliCredentials
+      -
+        Label:
           default: Media Lake Deployment Configuration
         Parameters:
           - SourceType
@@ -115,6 +128,8 @@ Metadata:
         default: OpenSearch Deployment Size
       ExternalS3Bucket:
         default: External S3 Bucket (Optional)
+      UseCliCredentials:
+        default: Use CLI Credentials Synthesizer
       SourceType:
         default: Source Type
       GitRepositoryUrl:
@@ -653,6 +668,8 @@ Resources:
             Value: !Ref DeploymentName
           - Name: IS_DEFAULT_DEPLOYMENT
             Value: !If [IsDefaultDeployment, 'true', 'false']
+          - Name: USE_CLI_CREDENTIALS
+            Value: !Ref UseCliCredentials
           - Name: VPC_CIDR
             Value: !GetAtt CidrAllocation.Cidr
       Source:
@@ -729,6 +746,14 @@ Resources:
                   else
                     echo "Additional deployment '$DEPLOYMENT_NAME' - using prefixed naming"
                     echo "$( jq '.use_prefixed_names = true' config.json )" > config.json
+                  fi
+                - |
+                  if [ "$USE_CLI_CREDENTIALS" = "true" ]; then
+                    echo "Using CLI credentials synthesizer"
+                    echo "$( jq '.deployment_options.use_cli_credentials = true' config.json )" > config.json
+                  else
+                    echo "Using default bootstrap role synthesizer"
+                    echo "$( jq '.deployment_options.use_cli_credentials = false' config.json )" > config.json
                   fi
                 # Set VPC CIDR from auto-allocated block (avoids collisions with existing VPCs)
                 - echo "Setting VPC CIDR to $VPC_CIDR"


### PR DESCRIPTION
This PR adds support for setting the deployment_options.use_cli_credentials via the Cloudformation template. It can be set via the `UseCliCredentials` CFN parameter. This will allow us to use the CLI Synthesizer via the CFN template.

It also support for adjusting the branch in CloudFormation templates. At the moment, the CloudFormation templates will always deploy the latest version of MediaLake. To make deployments more safe, this PR adds an optional `GitBranch` parameter that allows users to customize the branch, pointing to specific versions, for example.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.