### PR TITLE
Debug symbols are not useful at runtime. Stripping them.

### DIFF
--- a/medialake_constructs/shared_constructs/lambda_layers.py
+++ b/medialake_constructs/shared_constructs/lambda_layers.py
@@ -613,6 +613,7 @@ class FFProbeLayer(Construct):
                             tar xvf {self.FFMPEG_FILENAME} -C ffmpeg-extracted
                             mkdir -p ffprobe/bin
                             cp ffmpeg-extracted/*/bin/ffprobe ffprobe/bin/
+                            strip --strip-all ffprobe/bin/ffprobe
                             cd ffprobe
                             zip -9 -r $TEMP_DIR/ffprobe.zip .
                             cp $TEMP_DIR/ffprobe.zip /asset-output/


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
