### PR TITLE
feat: add support for MXF file uploads

### DIFF
--- a/lambdas/api/assets/upload/post_upload/index.py
+++ b/lambdas/api/assets/upload/post_upload/index.py
@@ -59,6 +59,7 @@ ALLOWED_CONTENT_TYPES = [
     "image/*",
     "application/x-mpegURL",  # HLS
     "application/dash+xml",  # MPEG-DASH
+    "application/mxf"
 ]
 # S3-compatible filename regex.
 # Allows: alphanumeric, S3 safe chars (!-_.*'()), and chars that require

--- a/medialake_user_interface/src/features/upload/components/FileUploader.tsx
+++ b/medialake_user_interface/src/features/upload/components/FileUploader.tsx
@@ -47,6 +47,7 @@ function getUppy() {
         "image/*",
         "application/x-mpegURL", // HLS
         "application/dash+xml", // MPEG-DASH
+        "application/mxf"
       ],
       maxNumberOfFiles: 500,
     },


### PR DESCRIPTION
*Description of changes:*

MXF files are documented as a supported format, but the current standard MIME type for MXF containers is application/mxf. Because the file filter only accepts the legacy video/mxf MIME type, valid MXF files are rejected.

This PR adds support for application/mxf, ensuring full MXF compatibility.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
