### PR TITLE
fix: add missing S3 permissions to connector Lambda role policy

### DIFF
--- a/lambdas/api/connectors/s3/post_s3/index.py
+++ b/lambdas/api/connectors/s3/post_s3/index.py
@@ -1538,6 +1538,8 @@ def create_connector(createconnector: S3Connector) -> dict:
                             "s3:GetObject",
                             "s3:ListBucket",
                             "s3:DeleteObject",  # Added for asset deletion
+                            "s3:GetBucketVersioning",  # Required by _should_process_deletion on delete events
+                            "s3:ListObjectVersions",  # Required when versioning is enabled
                         ],
                         "Resource": [
                             f"arn:aws:s3:::{s3_bucket}",


### PR DESCRIPTION
The S3 ingest Lambda's _should_process_deletion() method calls s3:GetBucketVersioning and s3:ListObjectVersions when processing ObjectRemoved events to determine if a deletion should be handled.

The connector role creation code (post_s3/index.py) was missing these actions in its inline S3 policy, causing AccessDenied errors in CloudWatch logs whenever a delete event was received.

Add both permissions to the connector Lambda's S3 policy statement. This applies to all connector roles created after this change.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
