### PR TITLE
fix(iam): correct PassRole resource pattern for transcribe service role

### DIFF
--- a/s3_bucket_assets/pipeline_nodes/node_templates/utility/audio_transcription_transcribe.yaml
+++ b/s3_bucket_assets/pipeline_nodes/node_templates/utility/audio_transcription_transcribe.yaml
@@ -21,7 +21,7 @@ node:
               actions:
                 - iam:PassRole
               resources:
-                - arn:aws:iam::${AWS::AccountId}:role/*_audio_transcription_transcribe_*
+                - arn:aws:iam::${AWS::AccountId}:role/*_transcribe_service_role
 
       service_roles:
         - name: transcribe_service_role


### PR DESCRIPTION
The iam:PassRole resource pattern used `*_audio_transcription_transcribe_*` but the actual service role name generated at runtime follows the pattern `{prefix}_{pipeline_name}_{node_id}_{role_suffix}`, producing names like `..._VideoTranscriptionndnode_1_transcribe_service_role`.

Update the pattern to `*_transcribe_service_role` to match the actual role naming convention used by create_service_role() in iam_operations.py.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
