### PR TITLE
fix(collections): add SSM_PREFIX to collections API Lambda for CloudF…

### DIFF
--- a/medialake_constructs/api_gateway/api_gateway_collections.py
+++ b/medialake_constructs/api_gateway/api_gateway_collections.py
@@ -188,6 +188,12 @@ class CollectionsApi(Construct):
                     "OPENSEARCH_INDEX": props.opensearch_index,
                     "SCOPE": "es",
                     "ENVIRONMENT": config.environment,
+                    # Needed by url_utils._get_cloudfront_domain() to resolve the
+                    # CloudFront domain SSM parameter (/{prefix}/{env}/cloudfront-
+                    # distribution-domain). Without this it falls back to
+                    # "/medialake/{env}", the wrong path for custom resource
+                    # prefixes, so collection thumbnail URLs come back null.
+                    "SSM_PREFIX": config.ssm_prefix,
                     "COLLECTIONS_INDEX_NAME": f"{config.resource_prefix}_collections_{config.environment}",
                     "MEDIA_ASSETS_BUCKET_NAME": props.media_assets_bucket.bucket.bucket_name,
                     "MEDIALAKE_ASSET_TABLE": props.asset_table.table_name,


### PR DESCRIPTION
…ront URL resolution

The collections_api Lambda serves GET /collections/{id}/assets, which builds asset thumbnail URLs via url_utils.generate_cloudfront_urls_batch() -> _get_cloudfront_domain(). That resolver reads the CloudFront domain from the SSM parameter at {SSM_PREFIX}/cloudfront-distribution-domain.

The Lambda never set SSM_PREFIX, so it fell back to the hard-coded /medialake/{env} path. For deployments with a custom resource_prefix the real parameter lives at /{resource_prefix}/{env}/..., so the lookup failed, the batch URL generation returned all None, and every thumbnailUrl came back null -> no thumbnails on the Collection page.

Set SSM_PREFIX to config.ssm_prefix, matching the earlier fix applied to the Assets and Search Lambdas. The ssm:GetParameter grant was already scoped to config.ssm_prefix, so only the env var was missing.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
